### PR TITLE
feat: Add CloudWatch Logs for AWS Batch Dependency

### DIFF
--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -79,35 +79,35 @@ tasks:
 - id: dbt_setup_and_run
   type: io.kestra.plugin.core.flow.WorkingDirectory
   tasks:
-    - id: git_clone_dbt_project # Clone the dbt repository
+    - id: git_clone_dbt_project
       type: io.kestra.plugin.git.Clone
       url: https://github.com/pizofreude/insightflow-retail-economic-pipeline.git
       branch: develop
+      destination: "{{ workingDir }}/cloned_repo"
 
     - id: dbt_deps
       type: io.kestra.plugin.dbt.cli.DbtCLI
       commands:
         - dbt deps
-      # Specify the dbt project directory relative to the cloned repository
-      projectDir: "{{ outputs.git_clone_dbt_project.outputFiles }}/dbt"
+      projectDir: "{{ workingDir }}/cloned_repo/dbt"
 
     - id: dbt_seed
       type: io.kestra.plugin.dbt.cli.DbtCLI
       commands:
         - dbt seed --target dev
-      projectDir: "{{ outputs.git_clone_dbt_project.outputFiles }}/dbt"
+      projectDir: "{{ workingDir }}/cloned_repo/dbt"
 
     - id: dbt_run
       type: io.kestra.plugin.dbt.cli.DbtCLI
       commands:
         - dbt run --target dev
-      projectDir: "{{ outputs.git_clone_dbt_project.outputFiles }}/dbt"
+      projectDir: "{{ workingDir }}/cloned_repo/dbt"
 
     - id: dbt_test
       type: io.kestra.plugin.dbt.cli.DbtCLI
       commands:
         - dbt test --target dev
-      projectDir: "{{ outputs.git_clone_dbt_project.outputFiles }}/dbt"
+      projectDir: "{{ workingDir }}/cloned_repo/dbt"
 
 # Optional: Add triggers (e.g., schedule)
 triggers:

--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -20,14 +20,11 @@ tasks:
   commands:
     - |
       echo "Submitting AWS Batch Job..."
-      # Fetch resource names/ARNs from Terraform outputs (replace placeholders)
-      JOB_DEF_NAME="insightflow-dev-ingestion-job-def" # Or use ARN: \{\{ tf(flow.namespace,'compute').outputs.batch_job_definition_arn \}\}
-      JOB_QUEUE_NAME="insightflow-dev-job-queue"       # Or use ARN: \{\{ tf(flow.namespace,'compute').outputs.batch_job_queue_arn \}\}
-      TARGET_BUCKET_NAME="insightflow-dev-raw-data"    # Or use TF output: \{\{ tf(flow.namespace,'storage').outputs.raw_s3_bucket_name \}\}
-      AWS_REGION="ap-southeast-2"                      # Or use flow input: \{\{ inputs.aws_region \}\}
+      JOB_DEF_NAME="insightflow-dev-ingestion-job-def"
+      JOB_QUEUE_NAME="insightflow-dev-job-queue"
+      TARGET_BUCKET_NAME="insightflow-dev-raw-data"
+      AWS_REGION="ap-southeast-2"
 
-      # Submit job and capture output (contains jobId)
-      # Note the JSON structure for containerOverrides. Environment values must be strings.
       JOB_NAME="insightflow-ingestion-{{execution.id}}"
       JOB_OUTPUT=$(aws batch submit-job \
         --region "$AWS_REGION" \
@@ -40,16 +37,9 @@ tasks:
             ]
           }')
 
-      # Extract Job ID (using grep and awk instead of jq)
       JOB_ID=$(echo "$JOB_OUTPUT" | grep -o '"jobId": "[^"]*' | awk -F'"' '{print $4}')
       echo "Submitted Job ID: $JOB_ID"
-      # Output the Job ID for potential use in later tasks
       echo '\{\{ outputs({"jobId": "'"$JOB_ID"'"}) \}\}'
-
-  # If you need to wait for the Batch job, you'd add a subsequent task
-  # using Bash/AWS CLI to poll `aws batch describe-jobs --jobs $JOB_ID`
-  # until status is SUCCEEDED or FAILED. This adds complexity.
-  # For now, we'll assume it runs reasonably fast or subsequent tasks handle delays.
 
 # -------------------------------------
 # 2. Update Glue Catalog via Crawler (using AWS CLI)
@@ -60,18 +50,17 @@ tasks:
     - |
       echo "Starting AWS Glue Crawler..."
       CRAWLER_NAME="insightflow-dev-raw-data-crawler"
-      AWS_REGION="ap-southeast-2" # Or use flow input
+      AWS_REGION="ap-southeast-2"
 
       aws glue start-crawler --region $AWS_REGION --name "$CRAWLER_NAME"
       echo "Crawler $CRAWLER_NAME started."
 
   # Similar to Batch, this doesn't wait for completion. Add delay or polling if needed.
 
-# --- Optional Delay ---
-- id: wait_for_crawler_and_batch
-  type: io.kestra.plugin.core.flow.Pause
-  delay: PT3M # Example: Pause for 3 minutes to give Batch/Crawler time
-
+# # --- Optional Delay ---
+# - id: wait_for_crawler_and_batch
+#   type: io.kestra.plugin.core.flow.Pause
+#   delay: PT3M # Example: Pause for 3 minutes to give Batch/Crawler time
 
 # -------------------------------------
 # 3. Run dbt Tasks (Requires dbt CLI plugin & access to dbt project files)
@@ -79,39 +68,44 @@ tasks:
 - id: dbt_setup_and_run
   type: io.kestra.plugin.core.flow.WorkingDirectory
   tasks:
-    - id: git_clone_dbt_project
-      type: io.kestra.plugin.git.Clone
-      url: https://github.com/pizofreude/insightflow-retail-economic-pipeline.git
-      branch: develop
-      destination: "{{ workingDir }}/cloned_repo"
+  - id: git_clone_dbt_project
+    type: io.kestra.plugin.git.Clone
+    url: https://github.com/pizofreude/insightflow-retail-economic-pipeline.git
+    branch: develop
+    directory: "git_clone_dbt_project"  # Use a relative path here
 
-    - id: dbt_deps
-      type: io.kestra.plugin.dbt.cli.DbtCLI
-      commands:
-        - dbt deps
-      projectDir: "{{ workingDir }}/cloned_repo/dbt"
+  - id: debug_git_clone
+    type: io.kestra.core.tasks.scripts.Bash
+    commands:
+      - ls -l git_clone_dbt_project
+      - ls -l git_clone_dbt_project/dbt
 
-    - id: dbt_seed
-      type: io.kestra.plugin.dbt.cli.DbtCLI
-      commands:
-        - dbt seed --target dev
-      projectDir: "{{ workingDir }}/cloned_repo/dbt"
+  - id: dbt_deps
+    type: io.kestra.plugin.dbt.cli.DbtCLI
+    commands:
+      - dbt deps
+    projectDir: "git_clone_dbt_project/dbt"  # Use a relative path here
 
-    - id: dbt_run
-      type: io.kestra.plugin.dbt.cli.DbtCLI
-      commands:
-        - dbt run --target dev
-      projectDir: "{{ workingDir }}/cloned_repo/dbt"
+  - id: dbt_seed
+    type: io.kestra.plugin.dbt.cli.DbtCLI
+    commands:
+      - dbt seed --target dev
+    projectDir: "git_clone_dbt_project/dbt"  # Use a relative path here
 
-    - id: dbt_test
-      type: io.kestra.plugin.dbt.cli.DbtCLI
-      commands:
-        - dbt test --target dev
-      projectDir: "{{ workingDir }}/cloned_repo/dbt"
+  - id: dbt_run
+    type: io.kestra.plugin.dbt.cli.DbtCLI
+    commands:
+      - dbt run --target dev
+    projectDir: "git_clone_dbt_project/dbt"  # Use a relative path here
+
+  - id: dbt_test
+    type: io.kestra.plugin.dbt.cli.DbtCLI
+    commands:
+      - dbt test --target dev
+    projectDir: "git_clone_dbt_project/dbt"  # Use a relative path here
 
 # Optional: Add triggers (e.g., schedule)
 triggers:
   - id: daily_schedule
     type: io.kestra.plugin.core.trigger.Schedule
-    cron: "0 5 * * *" # Example: Run daily at 5 AM UTC
-
+    cron: "0 5 * * *"

--- a/terraform/dev/02_compute/outputs.tf
+++ b/terraform/dev/02_compute/outputs.tf
@@ -43,3 +43,8 @@ output "kestra_server_ssh_command" {
   value       = "ssh -i /path/to/${var.kestra_key_name}.pem ec2-user@${aws_eip.kestra_eip.public_ip}" # Use Elastic IP if created
   # value       = "ssh -i /path/to/${var.kestra_key_name}.pem ec2-user@${aws_instance.kestra_server.public_ip}" # Use instance public IP if no EIP
 }
+
+output "cloudwatch_log_group_name" {
+  description = "Name of the CloudWatch log group for AWS Batch jobs."
+  value       = aws_cloudwatch_log_group.batch_job_logs.name
+}


### PR DESCRIPTION
This PR adds CloudWatch logs for AWS Batch dependency, enabling better monitoring and troubleshooting of batch jobs. The logs are configured to be stored in a log group named "batch_job_logs" with a retention period of 7 days.

This change is part of the ongoing effort to improve the reliability and maintainability of the Insightflow Retail Economic Pipeline.

## Summary by Sourcery

Add CloudWatch logging for AWS Batch jobs to improve monitoring and troubleshooting capabilities

New Features:
- Implemented CloudWatch log group for AWS Batch jobs with a 7-day retention period

Enhancements:
- Updated Kestra workflow configuration to use relative paths for dbt project tasks
- Modified Kestra host Dockerfile to improve Docker CLI and AWS CLI installation

CI:
- Added debug step to list git clone directory contents in Kestra workflow

Deployment:
- Added CloudWatch log group configuration in Terraform
- Updated Kestra host Docker configuration to support working directory mounting