### PR TITLE
Apply chmod as new bash task in insightflow_dev_pipeline.yml

### DIFF
--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -73,6 +73,9 @@ tasks:
     url: https://github.com/pizofreude/insightflow-retail-economic-pipeline.git
     branch: develop
     directory: "git_clone_dbt_project"  # Use a relative path here
+
+  - id: fix_permissions
+    type: io.kestra.core.tasks.scripts.Bash
     commands:
       - chmod -R 755 git_clone_dbt_project
 


### PR DESCRIPTION
This pull request applies chmod as a new bash task in the insightflow_dev_pipeline.yml file, ensuring proper permissions for the git_clone dbt_project.

## Summary by Sourcery

Chores:
- Added a bash task to recursively set 755 permissions on the git-cloned project directory