### PR TITLE
update dev pipeline for dbt

### DIFF
--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -80,31 +80,31 @@ tasks:
   - id: debug_synced_files
     type: io.kestra.core.tasks.scripts.Bash
     commands:
-      - ls -l "{{ workingDir }}/dbt"
+      - ls -l dbt
 
   - id: dbt_deps
     type: io.kestra.plugin.dbt.cli.DbtCLI
     commands:
       - dbt deps
-    projectDir: "{{ workingDir }}/dbt"
+    projectDir: "dbt"  # Use relative path within the WorkingDirectory
 
   - id: dbt_seed
     type: io.kestra.plugin.dbt.cli.DbtCLI
     commands:
       - dbt seed --target dev
-    projectDir: "{{ workingDir }}/dbt"
+    projectDir: "dbt"  # Use relative path within the WorkingDirectory
 
   - id: dbt_run
     type: io.kestra.plugin.dbt.cli.DbtCLI
     commands:
       - dbt run --target dev
-    projectDir: "{{ workingDir }}/dbt"
+    projectDir: "dbt"  # Use relative path within the WorkingDirectory
 
   - id: dbt_test
     type: io.kestra.plugin.dbt.cli.DbtCLI
     commands:
       - dbt test --target dev
-    projectDir: "{{ workingDir }}/dbt"
+    projectDir: "dbt"  # Use relative path within the WorkingDirectory
 
 # Optional: Add triggers (e.g., schedule)
 triggers:


### PR DESCRIPTION
Explanation of Changes
Removed {{ workingDir }}:

The WorkingDirectory plugin automatically sets the working directory for all child tasks. You don’t need to explicitly reference {{ workingDir }}.
The projectDir parameter now directly uses the relative path [dbt](vscode-file://vscode-app/c:/Users/AbdulHafeez/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
Debugging Task:

The debug_synced_files task verifies that the [dbt](vscode-file://vscode-app/c:/Users/AbdulHafeez/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) directory is correctly synced and accessible.

## Summary by Sourcery

Simplify the dbt development pipeline configuration by removing explicit working directory references and using relative paths

Enhancements:
- Streamline dbt task configurations by leveraging the WorkingDirectory plugin's automatic directory setting

Chores:
- Update project configuration to use more concise path references for dbt tasks