### PR TITLE
feat: Define S3 Staging Directory for DBT Seed

### DIFF
--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -95,6 +95,16 @@ tasks:
       - dbt seed --target dev
     namespaceFiles:
       enabled: false  # Disable automatic file sync for this task
+    profiles: |
+      default:
+        outputs:
+          dev:
+            type: athena
+            s3_staging_dir: "s3://insightflow-dev-processed-data/dbt-athena-results/"
+            region_name: "ap-southeast-2"
+            database: "your_database_name"
+            work_group: "primary"
+        target: dev
 
   - id: dbt_run
     type: io.kestra.plugin.dbt.cli.DbtCLI


### PR DESCRIPTION
This change defines the S3 staging directory for the DBT seed process in the insightflow_dev_pipeline.yml file. The s3_staging_dir property is set to "s3://insightflow-dev-processed-data/dbt-athena-results/" in the dev output profile. This should help improve the DBT seed process by specifying a dedicated S3 bucket for staging data.

## Summary by Sourcery

Configure S3 staging directory for DBT seed process in the development environment

New Features:
- Add S3 staging directory configuration for DBT Athena output in the dev profile

Enhancements:
- Specify a dedicated S3 bucket for staging DBT Athena results in the development pipeline