### PR TITLE
dbt-athena update: switch to official adapter

### DIFF
--- a/terraform/dev/02_compute/kestra_host.tf
+++ b/terraform/dev/02_compute/kestra_host.tf
@@ -130,8 +130,11 @@ RUN apt-get update && apt-get install -y docker.io && rm -rf /var/lib/apt/lists/
 # Remove existing 'docker' group (if it exists) and create a new one with the correct GID
 RUN groupdel docker || true && groupadd -g 992 docker && usermod -aG docker kestra
 
-# Install dbt-athena-community adapter
-RUN pip install dbt-athena-community
+# # Install dbt-athena-community adapter
+# RUN pip install dbt-athena-community
+
+# Install the official dbt-athena adapter
+RUN pip install dbt-athena
 
 # Switch back to the kestra user
 USER kestra


### PR DESCRIPTION
Update the Dockerfile to use the official `dbt-athena` adapter instead of `dbt-athena-community`.

## Summary by Sourcery

Chores:
- Replace the community dbt-athena adapter with the official adapter in the project's Dockerfile