### PR TITLE
Remove container definition in Kestra Workflow

### DIFF
--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -88,7 +88,6 @@ tasks:
       - dbt deps
     namespaceFiles:
       enabled: true
-    containerImage: kestra_kestra:latest
     
 
   - id: dbt_seed
@@ -109,7 +108,6 @@ tasks:
             database: "awsdatacatalog" # <<< SET THIS: Use Glue Data Catalog alias
             threads: 4
             work_group: "primary"
-    containerImage: kestra_kestra:latest
     
         
 
@@ -119,7 +117,6 @@ tasks:
       - dbt run --target dev
     namespaceFiles:
       enabled: true
-    containerImage: kestra_kestra:latest
     
 
   - id: dbt_test
@@ -128,7 +125,6 @@ tasks:
       - dbt test --target dev
     namespaceFiles:
       enabled: true
-    containerImage: kestra_kestra:latest
 
 # Optional: Add triggers (e.g., schedule)
 triggers:


### PR DESCRIPTION
Debugging kestra container persistent problem with dbt-athena:
- uninstall dbt-athena-community from kestra_kestra container
- install the official dbt-athena adapter to kestra_kestra container

## Summary by Sourcery

Remove custom container definitions from Kestra workflow tasks

Enhancements:
- Simplified Kestra workflow configuration by removing redundant container image specifications

Chores:
- Removed explicit 'containerImage' settings from multiple dbt-related tasks in the workflow