### PR TITLE
feat: change default kestra-dbt image and use custom kestra-dbt-athena image

### DIFF
--- a/dbt/models/marts/dim_date.sql
+++ b/dbt/models/marts/dim_date.sql
@@ -8,8 +8,8 @@
 with date_spine as (
     {{ dbt_utils.date_spine(
         datepart="day",
-        start_date="cast('2017-01-01' as date)", -- Adjust start date if needed based on data history
-        end_date="date_add('month', 1, current_date)" -- Go one month into the future to be safe
+        start_date="cast('2017-01-01' as date)",
+        end_date="date_add('month', 1, current_date)"
        )
     }}
 ),

--- a/kestra/docker/Dockerfile
+++ b/kestra/docker/Dockerfile
@@ -1,0 +1,5 @@
+# Use the base Kestra dbt image
+FROM ghcr.io/kestra-io/dbt:latest
+
+# Install the official dbt-athena-community adapter from PyPI
+RUN pip install dbt-athena-community

--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -88,7 +88,7 @@ tasks:
       - dbt deps
     namespaceFiles:
       enabled: true
-    containerImage: kestra-kestra:latest
+    containerImage: pizofreude/kestra-dbt-athena:latest
     
 
   - id: dbt_seed
@@ -109,7 +109,7 @@ tasks:
             database: "awsdatacatalog" # <<< SET THIS: Use Glue Data Catalog alias
             threads: 4
             work_group: "primary"
-    containerImage: kestra-kestra:latest        
+    containerImage: pizofreude/kestra-dbt-athena:latest   
 
   - id: dbt_run
     type: io.kestra.plugin.dbt.cli.DbtCLI
@@ -117,7 +117,7 @@ tasks:
       - dbt run --target dev
     namespaceFiles:
       enabled: true
-    containerImage: kestra-kestra:latest
+    containerImage: pizofreude/kestra-dbt-athena:latest
     
 
   - id: dbt_test
@@ -126,7 +126,7 @@ tasks:
       - dbt test --target dev
     namespaceFiles:
       enabled: true
-    containerImage: kestra-kestra:latest
+    containerImage: pizofreude/kestra-dbt-athena:latest
 
 # Optional: Add triggers (e.g., schedule)
 triggers:

--- a/terraform/dev/02_compute/kestra_host.tf
+++ b/terraform/dev/02_compute/kestra_host.tf
@@ -118,8 +118,8 @@ EOT
 
               # Add Dockerfile to extend Kestra image
               cat <<'EOT' > /home/ec2-user/kestra/Dockerfile
-# Use the Kestra base image
-FROM kestra/kestra:latest-full
+# Use the base Kestra dbt image
+FROM ghcr.io/kestra-io/dbt:latest
 
 # Switch to root to install the Docker CLI and configure groups
 USER root
@@ -133,8 +133,11 @@ RUN groupdel docker || true && groupadd -g 992 docker && usermod -aG docker kest
 # # Install dbt-athena-community adapter
 # RUN pip install dbt-athena-community
 
+# # Install the official dbt-athena adapter
+# RUN pip install dbt-athena
+
 # Install the official dbt-athena adapter
-RUN pip install dbt-athena
+RUN pip install git+https://github.com/dbt-athena/dbt-athena.git
 
 # Switch back to the kestra user
 USER kestra


### PR DESCRIPTION
Update the default Kestra DBT image to a custom image (`pizofreude/kestra-dbt-athena:latest`) and use the official DBT-Athena adapter for better compatibility and functionality.

## Summary by Sourcery

Update Kestra and dbt configuration to use a custom dbt-Athena image and the official dbt-Athena adapter for improved compatibility

New Features:
- Introduced a custom Kestra-dbt-Athena container image for improved dbt and Athena integration

Enhancements:
- Switched to the official dbt-Athena adapter for better database compatibility
- Updated Dockerfile to use a more specialized base image for dbt operations

Deployment:
- Created a new Dockerfile for custom Kestra-dbt-Athena image
- Updated container image references in Kestra flow configurations