### PR TITLE
Optimize Athena Performance: Add Bucketing/Clustering to InsightFlow Table

### DIFF
--- a/dbt/models/marts/fct_retail_sales_monthly.sql
+++ b/dbt/models/marts/fct_retail_sales_monthly.sql
@@ -3,9 +3,8 @@
 {{ config(
     materialized='table',
     partitioned_by=['year', 'month']
-    -- Optional: Add bucketing/clustering if desired for Athena performance tuning
-    -- clustered_by=['msic_group_key'],
-    -- buckets=16
+    clustered_by=['msic_group_key'],
+    buckets=16
     )
 }}
 


### PR DESCRIPTION
This PR adds bucketing and clustering to the InsightFlow table to improve Athena performance. The changes include:
* Adding bucketing with 16 buckets
* Configuring the table to be partitioned by 'year' and 'month'
* Optional: Adding clustering to further optimize performance

## Summary by Sourcery

Enhancements:
- Improve Athena query performance by adding bucketing with 16 buckets and clustering on the 'msic_group_key' column