### PR TITLE
 feat: add Kestra EC2 Athena access

### DIFF
--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -116,7 +116,7 @@ tasks:
     commands:
       - dbt run --target dev
     namespaceFiles:
-      enabled: true
+      enabled: false  # Disable automatic file sync for this task
     containerImage: pizofreude/kestra-dbt-athena:latest
     
 

--- a/terraform/dev/02_compute/main.tf
+++ b/terraform/dev/02_compute/main.tf
@@ -222,6 +222,43 @@ resource "aws_iam_role_policy_attachment" "kestra_ec2_s3_access" {
 }
 
 # Add other permissions as needed (e.g., Secrets Manager read)
+resource "aws_iam_policy" "kestra_athena_access_policy" {
+  name        = "${local.resource_prefix}-kestra-athena-access-policy"
+  description = "Allows Kestra tasks to interact with Athena and the Athena results S3 bucket"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "athena:StartQueryExecution",
+          "athena:GetQueryExecution",
+          "athena:GetQueryResults",
+          "athena:ListQueryExecutions"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket"
+        ],
+        Resource = [
+          "arn:aws:s3:::insightflow-dev-processed-data",
+          "arn:aws:s3:::insightflow-dev-processed-data/*"
+        ]
+      }
+    ]
+  })
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "kestra_ec2_athena_access" {
+  role       = aws_iam_role.kestra_ec2_role.name
+  policy_arn = aws_iam_policy.kestra_athena_access_policy.arn
+}
 
 resource "aws_iam_instance_profile" "kestra_ec2_profile" {
   name = local.kestra_ec2_profile_name

--- a/terraform/dev/02_compute/main.tf
+++ b/terraform/dev/02_compute/main.tf
@@ -234,7 +234,16 @@ resource "aws_iam_policy" "kestra_athena_access_policy" {
           "athena:StartQueryExecution",
           "athena:GetQueryExecution",
           "athena:GetQueryResults",
-          "athena:ListQueryExecutions"
+          "athena:ListQueryExecutions",
+          "athena:GetWorkGroup",
+          "athena:GetWorkGroup",
+          "athena:ListWorkGroups",
+          "athena:CreateWorkGroup",
+          "athena:DeleteWorkGroup",
+          "athena:UpdateWorkGroup",
+          "athena:ListTagsForResource",
+          "athena:TagResource",
+          "athena:UntagResource"
         ],
         Resource = "*"
       },


### PR DESCRIPTION
Automatically closes #issue-number This PR adds necessary AWS Athena and EC2 permissions to enable Kestra tasks to interact with Athena and the Athena results S3 bucket. It includes the creation of an IAM policy and role attachments for Kestra EC2 instance profile.