### PR TITLE
feat: disabling file sync during dbt_test

### DIFF
--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -125,7 +125,7 @@ tasks:
     commands:
       - dbt test --target dev
     namespaceFiles:
-      enabled: true
+      enabled: false  # Disable automatic file sync for this task
     containerImage: pizofreude/kestra-dbt-athena:latest
 
 # Optional: Add triggers (e.g., schedule)


### PR DESCRIPTION
This pull request disables file sync during the `dbt_test` command. The `namespaceFiles` section is updated to enable automatic file sync, but with the `enabled` property set to `false`. This change is made in the `kestra/flows/insightflow` directory.

## Summary by Sourcery

Enhancements:
- Modify namespace file sync configuration to disable automatic file synchronization for the dbt test task