### PR TITLE
Correct Athena Casting Logic

### DIFF
--- a/dbt/models/staging/stg_fuelprice.sql
+++ b/dbt/models/staging/stg_fuelprice.sql
@@ -16,7 +16,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    cast("date" as date) as record_date,
+    date_from_unixtime(cast("date" as bigint)) as record_date,
     cast(ron95 as double) as ron95_price_rm,
     cast(ron97 as double) as ron97_price_rm,
     cast(diesel as double) as diesel_peninsular_price_rm,

--- a/dbt/models/staging/stg_iowrt.sql
+++ b/dbt/models/staging/stg_iowrt.sql
@@ -15,7 +15,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    cast("date" as date) as record_date,
+    date_from_unixtime(cast("date" as bigint)) as record_date,
     cast(sales as double) as sales_value_rm_mil,
     cast(volume as double) as volume_index,
     cast(volume_sa as double) as volume_index_sa


### PR DESCRIPTION
Resolves an issue with Athena casting logic. This update corrects the data type casting and column renaming for the `stg_fuelprice` and `stg_iowrt` tables.

## Summary by Sourcery

Bug Fixes:
- Fix date casting in `stg_fuelprice` and `stg_iowrt` models by using `date_from_unixtime()` to properly convert Unix timestamps to date format