### PR TITLE
Cast data types and rename columns in staging tables

### DIFF
--- a/dbt/models/staging/stg_fuelprice.sql
+++ b/dbt/models/staging/stg_fuelprice.sql
@@ -16,7 +16,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    date_from_unixtime(cast("date" as bigint)) as record_date,
+    cast(from_unixtime(cast("date" as bigint)) as date) as record_date,
     cast(ron95 as double) as ron95_price_rm,
     cast(ron97 as double) as ron97_price_rm,
     cast(diesel as double) as diesel_peninsular_price_rm,

--- a/dbt/models/staging/stg_iowrt.sql
+++ b/dbt/models/staging/stg_iowrt.sql
@@ -15,7 +15,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    date_from_unixtime(cast("date" as bigint)) as record_date,
+    cast(from_unixtime(cast("date" as bigint)) as date) as record_date,
     cast(sales as double) as sales_value_rm_mil,
     cast(volume as double) as volume_index,
     cast(volume_sa as double) as volume_index_sa

--- a/dbt/models/staging/stg_iowrt_3d.sql
+++ b/dbt/models/staging/stg_iowrt_3d.sql
@@ -15,7 +15,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    cast("date" as date) as record_date,
+    cast(from_unixtime(cast("date" as bigint)) as date) as record_date,
     cast(group_code as varchar) as msic_group_code, -- Ensure group code is string
     cast(sales as double) as sales_value_rm_mil,
     cast(volume as double) as volume_index


### PR DESCRIPTION
This pull request updates the staging tables (`stg_fuelprice` and `stg_iowrt`) by casting data types and renaming columns to improve data consistency and accuracy. The changes include:

* Casting `date` columns to `date` type
* Renaming columns to follow a consistent naming convention

## Summary by Sourcery

Improve data type casting and column naming in staging tables for better data consistency

Enhancements:
- Standardize date column casting from Unix timestamp to date type across staging tables
- Rename columns to improve clarity and follow consistent naming conventions