### PR TITLE
Update column name 'group' to 'group_code' in msic_lookup.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Specifically, the pipeline will:
         
 4. [MSIC Lookup](https://open.dosm.gov.my/data-catalogue/msic)
     <details> <summary>Data Dictionary</summary>
+
+    >[!WARNING]
+    >The column name `group` in the `msic_lookup.csv` file conflicts with the reserved SQL keyword `GROUP` in Athena. When referenced in SQL without proper escaping, Athena interprets it as the keyword instead of a column name. Unfortunately, escaping using `“”` isn’t working either. The best solution is to change the column name `group` in `misc_lookup.csv` to `group_code`.
         
     ### **Dataset description**
     

--- a/dbt/models/staging/stg_msic_lookup.sql
+++ b/dbt/models/staging/stg_msic_lookup.sql
@@ -4,7 +4,7 @@ with source_data as (
     -- Select data from the seed file
     -- Ensure your msic_lookup.csv has headers: group_code, desc_en, desc_bm
     select
-        group as group_code, -- this column name in CSV holds the 3-digit code
+        group_code, -- this column name in CSV holds the 3-digit code
         desc_en,    -- this column name for English description
         desc_bm     -- this column name for Malay description
         -- Add other columns from the seed if needed

--- a/dbt/seeds/msic_lookup.csv
+++ b/dbt/seeds/msic_lookup.csv
@@ -1,4 +1,4 @@
-digits,section,division,group,class,item,desc_en,exclude_en,include_en,desc_bm,exclude_bm,include_bm
+digits,section,division,group_code,class,item,desc_en,exclude_en,include_en,desc_bm,exclude_bm,include_bm
 1,A,-,-,-,-,"Agriculture, forestry and fishing",,,"Pertanian, Perhutanan dan Perikanan",,
 1,B,-,-,-,-,Mining and quarrying,,,Perlombongan dan Pengkuarian,,
 1,C,-,-,-,-,Manufacturing,,,Pembuatan,,


### PR DESCRIPTION
* Update the column name 'group' to 'group_code' in the 'msic_lookup.csv' file to resolve a conflict with the reserved SQL keyword 'GROUP' in Athena.
* The change is necessary to prevent Athena from interpreting the column name as a keyword instead of a column name.
* This update aligns with the recommended solution to use a different column name to avoid conflicts.

## Summary by Sourcery

Rename the 'group' column to 'group_code' in msic_lookup.csv to resolve SQL keyword conflicts in Athena

Bug Fixes:
- Fix SQL query compatibility issue caused by column name conflicting with reserved Athena keyword 'GROUP'

Documentation:
- Add a warning note in README.md explaining the column name change and the reason behind it