### PR TITLE
fix: handling empty/null values for group_code

### DIFF
--- a/dbt/models/staging/stg_iowrt_3d.sql
+++ b/dbt/models/staging/stg_iowrt_3d.sql
@@ -9,8 +9,8 @@ with source_data as (
         sales,
         volume
     from {{ source('landing_zone', 'iowrt_3d') }}
-    -- Filter for absolute values
-    where series = 'abs'
+    where series = 'abs' -- Filter for absolute values
+      and group_code is not null and group_code != '' -- Filter out empty or null values
 )
 
 select

--- a/dbt/models/staging/stg_msic_lookup.sql
+++ b/dbt/models/staging/stg_msic_lookup.sql
@@ -9,6 +9,7 @@ with source_data as (
         desc_bm     -- this column name for Malay description
         -- Add other columns from the seed if needed
     from {{ ref('msic_lookup') }} -- Reference the seed file (msic_lookup.csv)
+    where group_code is not null and group_code != '' -- Filter out empty or null values
 )
 
 select


### PR DESCRIPTION
This PR addresses an issue where group_code values were not being handled correctly, resulting in null values. The changes include:
- Filtering out empty or null values for group_code
- Adding a condition to only select rows where group_code is not null
- Reference to the msic_lookup.csv seed file

Resolves issue by ensuring accurate data processing and preventing null values in the group_code column.

## Summary by Sourcery

Bug Fixes:
- Prevent processing of rows with empty or null group_code values in IOWRT 3D and MSIC lookup staging models