### PR TITLE
feat: Update ECR URI for AWS Batch and rename group column

### DIFF
--- a/kestra/flows/insightflow_dev_pipeline.yml
+++ b/kestra/flows/insightflow_dev_pipeline.yml
@@ -20,7 +20,7 @@ tasks:
   commands:
     - |
       echo "Submitting AWS Batch Job..."
-      JOB_DEF_NAME="insightflow-dev-ingestion-job-def"
+      JOB_DEF_NAME="insightflow-dev-ingestion-job-def" # Ensure this matches the updated aws job definition name in main.tf:resource and locals
       JOB_QUEUE_NAME="insightflow-dev-job-queue"
       TARGET_BUCKET_NAME="insightflow-dev-raw-data"
       AWS_REGION="ap-southeast-2"

--- a/src/ingestion/main.py
+++ b/src/ingestion/main.py
@@ -99,8 +99,18 @@ def upload_to_s3(data_bytes: bytes, bucket: str, s3_key: str) -> bool:
         logger.error(f"An unexpected error occurred during S3 upload to s3://{bucket}/{s3_key}: {e}")
         return False
 
+
 def process_and_upload(df: pd.DataFrame, dataset_name: str, date_column: str = 'date'):
     """Processes DataFrame rows and uploads them as individual Parquet files partitioned by date."""
+    # Handle column renaming for specific datasets
+    if dataset_name == "msic_lookup" or dataset_name == "iowrt_3d":
+        # Rename the 'group' column to 'group_code' to avoid Athena keyword conflicts
+        if "group" in df.columns:
+            df.rename(columns={"group": "group_code"}, inplace=True)
+            logger.info(f"Renamed 'group' column to 'group_code' for {dataset_name} dataset.")
+        else:
+            logger.warning(f"'group' column not found in {dataset_name} dataset. Skipping rename.")
+
     if df is None or df.empty:
         logger.warning(f"DataFrame for dataset '{dataset_name}' is empty or None. Skipping upload.")
         return
@@ -113,6 +123,8 @@ def process_and_upload(df: pd.DataFrame, dataset_name: str, date_column: str = '
     df = df.dropna(subset=[date_column])
 
     logger.info(f"Processing and uploading {len(df)} records for dataset '{dataset_name}'...")
+
+    # Logic for partitioning and uploading
 
     success_count = 0
     error_count = 0

--- a/terraform/dev/02_compute/variables.tf
+++ b/terraform/dev/02_compute/variables.tf
@@ -33,9 +33,10 @@ variable "tags" {
 variable "batch_container_image" {
   description = "ECR URI for the Docker container image for the Batch job."
   type        = string
-  default     = "public.ecr.aws/amazonlinux/amazonlinux:latest" # Placeholder - REPLACE LATER with your actual ECR image URI
+  default     = "864899839546.dkr.ecr.ap-southeast-2.amazonaws.com/insightflow-ingestion:latest"   # Placeholder - REPLACE LATER with your actual ECR image URI
   # default value is "public.ecr.aws/amazonlinux/amazonlinux:latest" as placeholder needed to be updated afterwards
-}
+} 
+  
 
 variable "batch_vcpu" {
   description = "Number of vCPUs for the Batch job container."


### PR DESCRIPTION
This pull request updates the ECR URI for the AWS Batch job container image and renames the 'group' column to 'group_code' to avoid Athena keyword conflicts. Additionally, it updates the AWS Batch job definition and adds a remark for the AWS Batch job definition in the Kestra workflow.

The changes include:
- Updating the ECR URI for the Docker container image for the Batch job.
- Renaming the 'group' column to 'group_code' for specific datasets.
- Updating the AWS Batch job definition.
- Adding a remark for the AWS Batch job definition in the Kestra workflow.

## Summary by Sourcery

Update AWS Batch job configuration, ECR image URI, and handle column renaming for specific datasets

New Features:
- Add environment variables to AWS Batch job definition

Bug Fixes:
- Rename 'group' column to 'group_code' to avoid Athena keyword conflicts

Enhancements:
- Update AWS Batch job definition with specific resource requirements
- Add timeout configuration for AWS Batch job

Deployment:
- Update ECR container image URI for AWS Batch job