### PR TITLE
feat: Add glue getDatabases permission and related actions

### DIFF
--- a/terraform/dev/02_compute/main.tf
+++ b/terraform/dev/02_compute/main.tf
@@ -282,6 +282,7 @@ resource "aws_iam_policy" "kestra_ec2_access_policy" {
         Action = [
           "glue:GetTable",
           "glue:GetDatabase",
+          "glue:GetDatabases", # Added permission for listing databases
           "glue:StartCrawler",
           "glue:GetCrawler"
         ],


### PR DESCRIPTION
Resolves issue by adding glue getDatabases permission and related actions for listing databases. Closes related issues by using closinq keywords.

## Summary by Sourcery

New Features:
- Introduced the ability to list Glue databases by adding 'glue:GetDatabases' permission to the IAM policy