### PR TITLE
fix: add s3 access for athena output bucket

### DIFF
--- a/terraform/dev/02_compute/main.tf
+++ b/terraform/dev/02_compute/main.tf
@@ -239,6 +239,21 @@ resource "aws_iam_policy" "kestra_ec2_access_policy" {
           "arn:aws:s3:::insightflow-dev-raw-data/*"
         ]
       },
+      # S3 Access for Athena Output Bucket
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject"
+        ],
+        Resource = [
+          "arn:aws:s3:::insightflow-dev-processed-data",
+          "arn:aws:s3:::insightflow-dev-processed-data/*"
+        ]
+      },      
       # DynamoDB Access
       {
         Effect = "Allow",


### PR DESCRIPTION
Add S3 access for Athena output bucket

## Summary by Sourcery

New Features:
- Added S3 access permissions for the Athena output bucket in the Kestra EC2 IAM policy