### PR TITLE
chore: Add remark for column rename in ingestion script; fix: use from_iso8601_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Specifically, the pipeline will:
         
     ### **Dataset description**
     
-    Performance of the wholesale & retail trade subsectors by MSIC group (3 digit), covering sales value and volume. The table provides a preview of the full dataset using the latest month of data only.
+    Performance of the wholesale & retail trade subsectors by MSIC group (3 digit), covering sales value and volume. The table provides a preview of the full dataset using the latest month of data only. The column name group is renamed to group_code in our ingestion script.
     
     ### **Variable definitions**
     

--- a/dbt/models/staging/stg_fuelprice.sql
+++ b/dbt/models/staging/stg_fuelprice.sql
@@ -16,7 +16,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    cast(from_unixtime(cast("date" as bigint)) as timestamp) as record_date,
+    from_iso8601_date("date") as record_date,
     cast(ron95 as double) as ron95_price_rm,
     cast(ron97 as double) as ron97_price_rm,
     cast(diesel as double) as diesel_peninsular_price_rm,

--- a/dbt/models/staging/stg_iowrt.sql
+++ b/dbt/models/staging/stg_iowrt.sql
@@ -15,7 +15,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    cast(from_unixtime(cast("date" as bigint)) as timestamp) as record_date,
+    from_iso8601_date("date") as record_date,
     cast(sales as double) as sales_value_rm_mil,
     cast(volume as double) as volume_index,
     cast(volume_sa as double) as volume_index_sa

--- a/dbt/models/staging/stg_iowrt_3d.sql
+++ b/dbt/models/staging/stg_iowrt_3d.sql
@@ -15,7 +15,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    cast(from_unixtime(cast("date" as bigint)) as timestamp) as record_date,
+    from_iso8601_date("date") as record_date,
     cast(group_code as varchar) as msic_group_code, -- Ensure group code is string
     cast(sales as double) as sales_value_rm_mil,
     cast(volume as double) as volume_index

--- a/dbt/models/staging/stg_msic_lookup.sql
+++ b/dbt/models/staging/stg_msic_lookup.sql
@@ -22,5 +22,5 @@ select
 from source_data
 -- Filter for only 3-digit codes if your seed contains other levels
 -- Assuming 3-digit codes have length 3
-where length(trim(msic_group_code)) = 3
+where length(trim(group_code)) = 3
 


### PR DESCRIPTION
This PR updates the ingestion script to reflect the column name change from `group` to `group_code`. Additionally, it includes a fix to use from_iso8601_date for date formatting.

## Summary by Sourcery

Update data transformation scripts to improve date parsing and column naming consistency

Bug Fixes:
- Fix date parsing to use more standard from_iso8601_date function instead of unix timestamp conversion

Enhancements:
- Replace unix timestamp conversion with ISO8601 date parsing across multiple staging models
- Update column name references from 'group' to 'group_code' in staging models

Documentation:
- Add clarification in README about group column renaming