### PR TITLE
Define seed output as Parquet format

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -59,6 +59,7 @@ seeds:
   insightflow: # Project name
     msic_lookup: # Specific seed file name (msic_lookup.csv)
       +schema: raw_seeds # Optional: Load seeds into a specific schema
+      +file_format: parquet # Save seed data in Parquet format
       +column_types: # Optional: Define column types explicitly if needed
           group_code: varchar
           desc_en: varchar


### PR DESCRIPTION
This pull request introduces a change to the `dbt_project.yml` file, specifically modifying the `msic_lookup` seed to save data in Parquet format. This can help improve data handling and compatibility within the project.

## Summary by Sourcery

Build:
- Specify Parquet as the file format for the `msic_lookup` seed in `dbt_project.yml`.