### PR TITLE
fix: rename all columns conflicted with sql reserved keywords

### DIFF
--- a/src/ingestion/main.py
+++ b/src/ingestion/main.py
@@ -103,13 +103,35 @@ def upload_to_s3(data_bytes: bytes, bucket: str, s3_key: str) -> bool:
 def process_and_upload(df: pd.DataFrame, dataset_name: str, date_column: str = 'date'):
     """Processes DataFrame rows and uploads them as individual Parquet files partitioned by date."""
     # Handle column renaming for specific datasets
-    if dataset_name == "msic_lookup" or dataset_name == "iowrt_3d":
-        # Rename the 'group' column to 'group_code' to avoid Athena keyword conflicts
+    if dataset_name == "iowrt":
+        # Rename 'date' to 'ymd_date'
+        if "date" in df.columns:
+            df.rename(columns={"date": "ymd_date"}, inplace=True)
+            logger.info(f"Renamed 'date' column to 'ymd_date' for {dataset_name} dataset.")
+        else:
+            logger.warning(f"'date' column not found in {dataset_name} dataset. Skipping rename.")
+
+    elif dataset_name == "iowrt_3d":
+        # Rename 'date' to 'ymd_date' and 'group' to 'group_code'
+        if "date" in df.columns:
+            df.rename(columns={"date": "ymd_date"}, inplace=True)
+            logger.info(f"Renamed 'date' column to 'ymd_date' for {dataset_name} dataset.")
+        else:
+            logger.warning(f"'date' column not found in {dataset_name} dataset. Skipping rename.")
+
         if "group" in df.columns:
             df.rename(columns={"group": "group_code"}, inplace=True)
             logger.info(f"Renamed 'group' column to 'group_code' for {dataset_name} dataset.")
         else:
             logger.warning(f"'group' column not found in {dataset_name} dataset. Skipping rename.")
+
+    elif dataset_name == "fuelprice":
+        # Rename 'date' to 'ymd_date'
+        if "date" in df.columns:
+            df.rename(columns={"date": "ymd_date"}, inplace=True)
+            logger.info(f"Renamed 'date' column to 'ymd_date' for {dataset_name} dataset.")
+        else:
+            logger.warning(f"'date' column not found in {dataset_name} dataset. Skipping rename.")
 
     if df is None or df.empty:
         logger.warning(f"DataFrame for dataset '{dataset_name}' is empty or None. Skipping upload.")
@@ -123,6 +145,9 @@ def process_and_upload(df: pd.DataFrame, dataset_name: str, date_column: str = '
     df = df.dropna(subset=[date_column])
 
     logger.info(f"Processing and uploading {len(df)} records for dataset '{dataset_name}'...")
+
+    # Logic for partitioning and uploading
+    ...
 
     # Logic for partitioning and uploading
 


### PR DESCRIPTION
## Summary by Sourcery

Rename 'date' and 'group' columns in specific datasets during ingestion to avoid SQL keyword conflicts.

Bug Fixes:
- Rename 'date' to 'ymd_date' in 'iowrt', 'iowrt_3d', and 'fuelprice' datasets.
- Rename 'group' to 'group_code' in the 'iowrt_3d' dataset.
- Remove obsolete 'group' column renaming for the 'msic_lookup' dataset which might have caused issues previously if the column existed there without needing a rename

Enhancements:
- Check for column existence before attempting renaming.
- Add logging for column renaming operations.