### PR TITLE
Update column names in sources.yml and add stg_iowrt test for ymd_date

### DIFF
--- a/dbt/models/marts/schema.yml
+++ b/dbt/models/marts/schema.yml
@@ -69,3 +69,11 @@ models:
         description: "Average monthly RON95 price."
         # Add tests if needed, e.g., check for reasonable price range
 
+      - name: stg_iowrt
+        description: "Date-validated in staging table for iowrt data."
+        columns:
+          - name: ymd_date
+            tests:
+              - not_null
+              - unique
+

--- a/dbt/models/sources.yml
+++ b/dbt/models/sources.yml
@@ -12,7 +12,7 @@ sources:
         columns:
           - name: series # Original column names from source Parquet/JSON
             description: "Series type ('abs', 'growth_yoy', 'growth_mom')"
-          - name: date
+          - name: ymd_date
             description: "Date of record (YYYY-MM-DD, monthly frequency)"
           - name: sales
             description: "Sales Value (RM mil)"
@@ -29,9 +29,9 @@ sources:
         columns:
           - name: series
             description: "Series type ('abs', 'growth_yoy', 'growth_mom')"
-          - name: date
+          - name: ymd_date
             description: "Date of record (YYYY-MM-DD, monthly frequency)"
-          - name: group # Note: This is the 3-digit MSIC code
+          - name: group_code # Note: This is the 3-digit MSIC code
             description: "MSIC Group Code (3-digit)"
           - name: sales
             description: "Sales Value (RM mil)"
@@ -43,7 +43,7 @@ sources:
         columns:
           - name: series_type
             description: "Chart Type ('level', 'change_weekly')"
-          - name: date
+          - name: ymd_date
             description: "Date of effect (YYYY-MM-DD, weekly frequency)"
           - name: ron95
             description: "RON95 Price (RM/litre)"

--- a/dbt/models/staging/stg_fuelprice.sql
+++ b/dbt/models/staging/stg_fuelprice.sql
@@ -4,7 +4,7 @@ with source_data as (
     -- Select data from the raw source table created by Glue Crawler
     select
         series_type,
-        "date",
+        ymd_date, -- Updated column name
         ron95,
         ron97,
         diesel,
@@ -16,7 +16,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    from_unixtime(cast("date" as bigint)) as record_date,
+    cast(ymd_date as date) as record_date,
     cast(ron95 as double) as ron95_price_rm,
     cast(ron97 as double) as ron97_price_rm,
     cast(diesel as double) as diesel_peninsular_price_rm,

--- a/dbt/models/staging/stg_iowrt.sql
+++ b/dbt/models/staging/stg_iowrt.sql
@@ -4,7 +4,7 @@ with source_data as (
     -- Select data from the raw source table created by Glue Crawler
     select
         series,
-        "date", -- Quoted because date is a reserved keyword in some SQL dialects
+        ymd_date, -- Updated column name
         sales,
         volume,
         volume_sa
@@ -15,7 +15,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    from_unixtime(cast("date" as bigint)) as record_date,
+    cast(ymd_date as date) as record_date,
     cast(sales as double) as sales_value_rm_mil,
     cast(volume as double) as volume_index,
     cast(volume_sa as double) as volume_index_sa

--- a/dbt/models/staging/stg_iowrt_3d.sql
+++ b/dbt/models/staging/stg_iowrt_3d.sql
@@ -4,7 +4,7 @@ with source_data as (
     -- Select data from the raw source table created by Glue Crawler
     select
         series,
-        "date",
+        ymd_date, -- Updated column name
         group_code, -- Rename 'group' column
         sales,
         volume
@@ -15,7 +15,7 @@ with source_data as (
 
 select
     -- Cast data types and rename columns
-    cast("date" as timestamp) as record_date,
+    cast(ymd_date as date) as record_date,
     cast(group_code as varchar) as msic_group_code, -- Ensure group code is string
     cast(sales as double) as sales_value_rm_mil,
     cast(volume as double) as volume_index


### PR DESCRIPTION
This pull request introduces changes to the `sources.yml` file, updating column names and adding a new test for the `stg_iowrt` model. It also includes a new `stg_iowrt` test for the `ymd_date` column. These changes are aimed at improving data consistency and integrity.

## Summary by Sourcery

Standardize the primary date column name to `ymd_date` across relevant sources and staging models, and add date validation tests.

Enhancements:
- Rename the `date` column to `ymd_date` in `dosm_iowrt`, `dosm_iowrt_3d`, and `dosm_fuelprice` sources and update corresponding staging models (`stg_iowrt`, `stg_iowrt_3d`, `stg_fuelprice`).
- Rename the `group` column to `group_code` in the `dosm_iowrt_3d` source and `msic_group_code` in the `stg_iowrt_3d` staging model.
- Update date casting logic in affected staging models to use the new `ymd_date` column and ensure correct type casting to DATE.
- Define the `stg_iowrt` model structure within the marts schema file (`marts/schema.yml`).

Tests:
- Add `not_null` and `unique` tests for the `ymd_date` column in the `stg_iowrt` model definition.