### PR TITLE
fix: use from_unixtime for record_date cnv

### DIFF
--- a/dbt/models/staging/stg_fuelprice.sql
+++ b/dbt/models/staging/stg_fuelprice.sql
@@ -4,7 +4,8 @@ with source_data as (
     -- Select data from the raw source table created by Glue Crawler
     select
         series_type,
-        cast(from_unixtime(ymd_date) as date) as record_date, -- Convert Unix timestamp to date, Updated column name
+        -- Convert ymd_date from nanoseconds to a proper timestamp and alias it as record_date
+        from_unixtime(cast(ymd_date / 1000000000 as bigint)) as record_date,
         ron95,
         ron97,
         diesel,
@@ -15,7 +16,7 @@ with source_data as (
 )
 
 select
-    -- Cast data types and rename columns
+    -- Use record_date as the alias for the converted timestamp
     record_date,
     cast(ron95 as double) as ron95_price_rm,
     cast(ron97 as double) as ron97_price_rm,


### PR DESCRIPTION
## Summary by Sourcery

Correct the calculation of `record_date` in the `stg_fuelprice` model.

Bug Fixes:
- Convert the `ymd_date` timestamp from nanoseconds to seconds before processing with `from_unixtime`.
- Ensure `record_date` retains the timestamp type instead of being cast to date.