### PR TITLE
Fixes in stg_msic_lookup references and column handling

### DIFF
--- a/dbt/models/marts/dim_msic_group.sql
+++ b/dbt/models/marts/dim_msic_group.sql
@@ -5,11 +5,11 @@
 with ranked_descriptions as (
     select
         msic_group_code,  -- Use the renamed column from stg_msic_lookup
-        desc_en,
-        desc_bm,
+        group_desc_en as desc_en, -- Use the alias from stg_msic_lookup
+        group_desc_bm as desc_bm, -- Use the alias from stg_msic_lookup
         row_number() over (
             partition by msic_group_code
-            order by length(desc_en) desc, length(desc_bm) desc
+            order by length(group_desc_en) desc, length(group_desc_bm) desc
         ) as rank
     from {{ ref('stg_msic_lookup') }}
 )

--- a/dbt/models/staging/stg_iowrt.sql
+++ b/dbt/models/staging/stg_iowrt.sql
@@ -4,7 +4,7 @@ with source_data as (
     -- Select data from the raw source table created by Glue Crawler
     select
         series,
-        cast(from_unixtime(ymd_date) as date) as record_date, -- Convert Unix timestamp to date, Updated column name
+        cast(ymd_date as date) as record_date, -- Directly cast to date, Updated column name
         sales,
         volume,
         volume_sa

--- a/dbt/models/staging/stg_msic_lookup.sql
+++ b/dbt/models/staging/stg_msic_lookup.sql
@@ -22,5 +22,5 @@ select
 from source_data
 -- Filter for only 3-digit codes if your seed contains other levels
 -- Assuming 3-digit codes have length 3
-where length(trim(group_code)) = 3
+-- where length(trim(group_code)) = 3
 


### PR DESCRIPTION
This pull request (PR) includes several fixes for the `stg_msic_lookup` component. It addresses improper references, removes unnecessary `group_code` trimming, and correctly casts the `ymd_date` to date format. The changes are committed in three separate commits, with details available in the commit history.

## Summary by Sourcery

Update dbt models to correct data handling and references.

Bug Fixes:
- Update `dim_msic_group` to use correct column names (`group_desc_en`, `group_desc_bm`) from `stg_msic_lookup`.
- Correct the casting of the `ymd_date` column to date format in `stg_iowrt`.
- Remove the filter restricting `group_code` to 3 digits in `stg_msic_lookup`.